### PR TITLE
Doc : update poetry installation

### DIFF
--- a/docs/requirements/python_poetry_install.md
+++ b/docs/requirements/python_poetry_install.md
@@ -24,7 +24,7 @@ sudo apt install python3.9
 Install Poetry :
 
 ```sh
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3.9 -
-source $HOME/.poetry/env
-poetry --version
+# poetry is installed in $HOME/.local/bin
+curl -sSL https://install.python-poetry.org | python3 -
+export PATH="$HOME/.local/bin:$PATH"
 ```


### PR DESCRIPTION
The described way of installing poetry is not supported and not working anymore (cf [the doc](https://python-poetry.org/docs/#installing-with-the-official-installer)). 

Installing with my proposed fix is working on my side, but if @IceManGreen you wanna check more thorougly about if everything is working properly feel free to do so.